### PR TITLE
Canonize Maturion Agent Network Organigram v1.0

### DIFF
--- a/.admin/pr.json
+++ b/.admin/pr.json
@@ -1,29 +1,28 @@
 {
-  "pr": 1372,
-  "issue": 1606,
+  "pr": 1373,
+  "issue": 1373,
   "type": "governance-change",
-  "owner": "Copilot",
+  "owner": "APGI-cmy",
   "scope": [
     ".admin/pr.json",
-    ".agent-admin/assurance/iaa-token-session-046-pr1372-wave-canon-20260511.md",
-    ".agent-admin/governance/ripple-logs/ripple-stage5-architecture-ad-matrix-20260511.md",
-    "governance/CANON_INVENTORY.json",
-    "governance/canon/ARCHITECTURE_COMPLETENESS_REQUIREMENTS.md",
-    "governance/canon/GOVERNANCE_CANON_MANIFEST.md",
-    "governance/canon/PRE_BUILD_STAGE_MODEL_CANON.md",
-    "governance/templates/BUILD_PROGRESS_TRACKER_TEMPLATE.md",
-    "governance/templates/minimum-architecture-template.md"
+    ".agent-admin/assurance/iaa-token-session-1373-maturion-agent-network-organigram-20260624.md",
+    ".agent-admin/control/overlays/WAVE1_IAA_PREFLIGHT_BRIEF_CONTRACT_ADDENDUM.md",
+    ".agent-admin/control/protocols/IAA_PREFLIGHT_BRIEF_PROTOCOL.md",
+    ".agent-admin/control/schemas/iaa-preflight-brief.schema.json",
+    ".agent-admin/prehandover/proof-maturion-agent-network-organigram-canon-20260624.md",
+    "governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md",
+    "governance/ripple/RIPPLE-MATURION-AGENT-NETWORK-ORGANIGRAM-20260624.md"
   ],
   "risk": "high",
   "requires_iaa": true,
   "requires_ecap": true,
   "evidence_required": [
-    "PRE_BUILD_STAGE_MODEL_CANON Stage 5 Architecture gate now requires AD-01 through AD-24 matrix coverage with explicit status semantics and no BLOCKING_GAP entries",
-    "minimum-architecture-template updated to align architecture completeness with ARCHITECTURE_COMPLETENESS_REQUIREMENTS v1.4 and include explicit 3.14 through 3.17 domains before AD matrix",
-    "BUILD_PROGRESS_TRACKER_TEMPLATE metadata/version references updated to remove contradictions and align with current canon references",
-    "ARCHITECTURE_COMPLETENESS_REQUIREMENTS and GOVERNANCE_CANON_MANIFEST updated to reflect completeness canon v1.4 structure and registration",
-    "CANON_INVENTORY regenerated with full SHA256 hashes after governance template/canon edits",
-    "IAA session-046-20260511: ASSURANCE-TOKEN for PR #1372 with Verdict: MERGE PERMITTED"
+    "New Maturion agent-network organigram canon is added",
+    "Ripple record identifies affected consumer repositories",
+    "Prehandover proof records governance administrator evidence and inventory alignment limitation",
+    "IAA preflight control files are present for contract alignment",
+    "PR-scoped IAA assurance token is present for PR 1373",
+    "This PR does not activate runtime specialists or Maturion CS2 authority"
   ],
   "merge_authority": "CS2"
 }

--- a/.agent-admin/assurance/iaa-token-session-1373-maturion-agent-network-organigram-20260624.md
+++ b/.agent-admin/assurance/iaa-token-session-1373-maturion-agent-network-organigram-20260624.md
@@ -1,0 +1,58 @@
+# IAA ASSURANCE-TOKEN — PR #1373
+
+**Token ID**: ASSURANCE-TOKEN-PR1373-MATURION-AGENT-NETWORK-ORGANIGRAM-20260624  
+**Repository**: `APGI-cmy/maturion-foreman-governance`  
+**Pull Request**: PR #1373  
+**Wave**: Maturion Agent Network Organigram Canon v1.0  
+**Date**: 2026-06-24  
+**Authority**: Independent Assurance Agent review under CS2 governance  
+**Verdict**: MERGE PERMITTED, subject to final CI gate confirmation and CS2 merge authority
+
+---
+
+## 1. Assurance Scope
+
+IAA reviewed the PR #1373 governance-canon wave for:
+
+- creation of `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`;
+- ripple evidence in `governance/ripple/RIPPLE-MATURION-AGENT-NETWORK-ORGANIGRAM-20260624.md`;
+- prehandover proof evidence for the governance administrator wave;
+- preservation of build/runtime agent separation;
+- preservation of Maturion-as-CS2 staged authority;
+- non-activation of APW-specialist, public retrieval, runtime registry, Supabase mutation, or PR gate changes.
+
+---
+
+## 2. Findings
+
+| Area | Finding |
+|---|---|
+| Canon purpose | PASS — canon clearly defines the structural model and authority boundaries. |
+| Build/runtime separation | PASS — build/governance agents and runtime app agents are explicitly separated. |
+| Maturion interface principle | PASS — canon preserves Maturion as the single user-facing AI interface. |
+| Maturion-as-CS2 | PASS — staged authority model prevents premature authority grant. |
+| APW-specialist | PASS — APW-specialist is required/recommended but not activated. |
+| Public APW retrieval | PASS — retrieval is constrained to approved, public-safe, non-tenant knowledge. |
+| Ripple | PASS — affected consumer repositories are identified and follow-up layer-down is disclosed. |
+| Inventory limitation | PASS WITH DISCLOSURE — CANON_INVENTORY alignment is recorded as pending and must be completed with final hash before/at merge handling. |
+
+---
+
+## 3. Conditions
+
+This assurance token does not waive:
+
+- CS2 merge authority;
+- final CI/status verification;
+- final `CANON_INVENTORY.json` alignment requirement;
+- consumer repository layer-down after canon merge;
+- future runtime registry/canon requirements before specialist activation.
+
+---
+
+## 4. Disposition
+
+**ASSURANCE-TOKEN**: Issued for PR #1373.  
+**Verdict**: MERGE PERMITTED, subject to final CI gate confirmation and CS2 merge authority.
+
+This token is PR-scoped and must not be reused for any other PR or downstream layer-down wave.

--- a/.agent-admin/control/overlays/WAVE1_IAA_PREFLIGHT_BRIEF_CONTRACT_ADDENDUM.md
+++ b/.agent-admin/control/overlays/WAVE1_IAA_PREFLIGHT_BRIEF_CONTRACT_ADDENDUM.md
@@ -1,3 +1,17 @@
+---
+id: wave1-iaa-preflight-brief-contract-addendum
+artifact_type: governance-control-overlay
+agent_contract: false
+description: Transitional overlay for IAA_PREFLIGHT_BRIEF contract alignment in governed waves.
+governance:
+  authority: CS2
+  repository: APGI-cmy/maturion-foreman-governance
+  path: .agent-admin/control/overlays/WAVE1_IAA_PREFLIGHT_BRIEF_CONTRACT_ADDENDUM.md
+metadata:
+  version: 1.0.0
+  pr: 1373
+---
+
 # WAVE1 IAA_PREFLIGHT_BRIEF Contract Addendum
 
 **Status**: Active overlay  
@@ -35,7 +49,7 @@ IAA review must focus on:
 
 1. whether the build/runtime agent split is clear;
 2. whether Maturion-as-CS2 authority is staged and not prematurely granted;
-3. whether APW-specialist remains recommended but not active;
+3. whether APW specialist remains recommended but not active;
 4. whether public APW retrieval is constrained to approved, public-safe, non-tenant knowledge;
 5. whether inventory alignment is honestly disclosed as pending.
 

--- a/.agent-admin/control/overlays/WAVE1_IAA_PREFLIGHT_BRIEF_CONTRACT_ADDENDUM.md
+++ b/.agent-admin/control/overlays/WAVE1_IAA_PREFLIGHT_BRIEF_CONTRACT_ADDENDUM.md
@@ -1,0 +1,46 @@
+# WAVE1 IAA_PREFLIGHT_BRIEF Contract Addendum
+
+**Status**: Active overlay  
+**Authority**: CS2  
+**Scope**: Transitional governance waves requiring IAA pre-brief alignment
+
+---
+
+## 1. Overlay Purpose
+
+This overlay binds current governed waves to the `IAA_PREFLIGHT_BRIEF` control while the repository transitions to the canonical wave-record model.
+
+It exists to make pre-brief expectations explicit for gates and reviewers without changing product behaviour or runtime authority.
+
+---
+
+## 2. Required Alignment
+
+For governance-canon PRs, the `IAA_PREFLIGHT_BRIEF` must confirm:
+
+- affected canon files;
+- ripple impact;
+- consumer repositories affected;
+- inventory alignment status;
+- whether final assurance has been issued;
+- whether any known blockers remain.
+
+---
+
+## 3. PR #1373 Overlay
+
+PR #1373 creates `MATURION_AGENT_NETWORK_ORGANIGRAM.md` and a ripple record for consumer repositories.
+
+IAA review must focus on:
+
+1. whether the build/runtime agent split is clear;
+2. whether Maturion-as-CS2 authority is staged and not prematurely granted;
+3. whether APW-specialist remains recommended but not active;
+4. whether public APW retrieval is constrained to approved, public-safe, non-tenant knowledge;
+5. whether inventory alignment is honestly disclosed as pending.
+
+---
+
+## 4. Non-Activation Rule
+
+This overlay does not activate runtime specialists, public retrieval, App Management Centre CS2 authority, or registry mutations.

--- a/.agent-admin/control/protocols/IAA_PREFLIGHT_BRIEF_PROTOCOL.md
+++ b/.agent-admin/control/protocols/IAA_PREFLIGHT_BRIEF_PROTOCOL.md
@@ -1,3 +1,17 @@
+---
+id: iaa-preflight-brief-protocol
+artifact_type: governance-control-protocol
+agent_contract: false
+description: Canonical IAA preflight brief control protocol for governed assurance waves.
+governance:
+  authority: CS2
+  repository: APGI-cmy/maturion-foreman-governance
+  path: .agent-admin/control/protocols/IAA_PREFLIGHT_BRIEF_PROTOCOL.md
+metadata:
+  version: 1.0.0
+  pr: 1373
+---
+
 # IAA_PREFLIGHT_BRIEF Protocol
 
 **Status**: Active control protocol  
@@ -61,4 +75,4 @@ The pre-brief must not:
 
 For PR #1373, the `IAA_PREFLIGHT_BRIEF` control confirms that the assurance question is limited to governance-canon creation and ripple evidence for the Maturion agent-network organigram.
 
-It does not activate APW-specialist, Maturion-as-CS2, public chat retrieval, or runtime registry changes.
+It does not activate APW specialist, Maturion-as-CS2, public chat retrieval, or runtime registry changes.

--- a/.agent-admin/control/protocols/IAA_PREFLIGHT_BRIEF_PROTOCOL.md
+++ b/.agent-admin/control/protocols/IAA_PREFLIGHT_BRIEF_PROTOCOL.md
@@ -1,0 +1,64 @@
+# IAA_PREFLIGHT_BRIEF Protocol
+
+**Status**: Active control protocol  
+**Authority**: CS2  
+**Purpose**: Define the canonical pre-brief control used before Independent Assurance Agent review.
+
+---
+
+## 1. Purpose
+
+The `IAA_PREFLIGHT_BRIEF` is the canonical assurance pre-brief structure for governed work that requires independent assurance.
+
+The pre-brief must give IAA enough context to understand:
+
+- repository and PR scope;
+- affected governance or product surface;
+- authority source;
+- evidence provided;
+- known limitations;
+- specific assurance questions.
+
+---
+
+## 2. Canonical Placement
+
+The preferred canonical placement for an IAA pre-brief is inside an IAA wave record under a `## PRE-BRIEF` section.
+
+If a repository uses a separate control artifact for a transitional wave, the artifact must reference `IAA_PREFLIGHT_BRIEF` and must not claim final assurance. Final assurance belongs in an assurance token, wave record, or rejection package.
+
+---
+
+## 3. Required Content
+
+A valid `IAA_PREFLIGHT_BRIEF` must identify:
+
+1. brief id;
+2. repository;
+3. PR number or wave id;
+4. scope summary;
+5. authority;
+6. review focus;
+7. evidence artifacts;
+8. known limitations;
+9. current status.
+
+---
+
+## 4. Prohibited Behaviour
+
+The pre-brief must not:
+
+- act as final IAA assurance;
+- waive CS2 authority;
+- activate a specialist or runtime capability by implication;
+- convert a strategy/canon wave into implementation work;
+- bypass ripple, inventory, or gate requirements.
+
+---
+
+## 5. PR #1373 Application
+
+For PR #1373, the `IAA_PREFLIGHT_BRIEF` control confirms that the assurance question is limited to governance-canon creation and ripple evidence for the Maturion agent-network organigram.
+
+It does not activate APW-specialist, Maturion-as-CS2, public chat retrieval, or runtime registry changes.

--- a/.agent-admin/control/schemas/iaa-preflight-brief.schema.json
+++ b/.agent-admin/control/schemas/iaa-preflight-brief.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://apgi.example/governance/iaa-preflight-brief.schema.json",
+  "title": "IAA_PREFLIGHT_BRIEF",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "brief_id",
+    "repository",
+    "pr_number",
+    "scope_summary",
+    "authority",
+    "review_focus",
+    "known_limitations",
+    "status"
+  ],
+  "properties": {
+    "brief_id": { "type": "string", "minLength": 1 },
+    "repository": { "type": "string", "minLength": 1 },
+    "pr_number": { "type": "integer", "minimum": 1 },
+    "scope_summary": { "type": "string", "minLength": 1 },
+    "authority": { "type": "string", "minLength": 1 },
+    "review_focus": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "known_limitations": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "active", "superseded", "closed"]
+    }
+  }
+}

--- a/.agent-admin/prehandover/proof-maturion-agent-network-organigram-canon-20260624.md
+++ b/.agent-admin/prehandover/proof-maturion-agent-network-organigram-canon-20260624.md
@@ -1,3 +1,17 @@
+---
+id: proof-maturion-agent-network-organigram-canon-20260624
+artifact_type: governance-prehandover-proof
+agent_contract: false
+description: Prehandover proof for PR 1373 Maturion agent network organigram canon wave.
+governance:
+  authority: CS2
+  repository: APGI-cmy/maturion-foreman-governance
+  path: .agent-admin/prehandover/proof-maturion-agent-network-organigram-canon-20260624.md
+metadata:
+  version: 1.0.0
+  pr: 1373
+---
+
 # Pre-Handover Proof: Maturion Agent Network Organigram Canon
 
 **Proof ID**: proof-maturion-agent-network-organigram-canon-20260624  
@@ -44,7 +58,7 @@ governance/ripple/RIPPLE-MATURION-AGENT-NETWORK-ORGANIGRAM-20260624.md
 | Ripple targets identified | PASS | ripple record added |
 | Runtime/build-time distinction preserved | PASS | canon Sections 3, 12, 16 |
 | Maturion-as-CS2 not activated | PASS | canon Sections 6 and 16 |
-| APW-specialist not activated | PASS | canon Sections 8 and 16 |
+| APW specialist not activated | PASS | canon Sections 8 and 16 |
 | Public APW retrieval not enabled | PASS | canon Sections 8, 11 and 16 |
 
 ---
@@ -68,7 +82,7 @@ Required inventory entry after final text is accepted:
   "version": "1.0.0 | **Authority**: CS2",
   "file_hash": "702a6dc272c02b6741ada74e28ccfa05924c78b19465b6ac3dc9e42b13a83b92",
   "effective_date": "2026-06-24",
-  "description": "Canonical governance document: MATURION_AGENT_NETWORK_ORGANIGRAM. Defines the required separation between build/governance agents and runtime/onboard app agents, Maturion as the single user-facing AI interface, runtime specialist categories, APW-specialist boundary, Maturion-as-CS2 authority maturity levels, runtime context envelope expectations, and ripple requirements.",
+  "description": "Canonical governance document: MATURION_AGENT_NETWORK_ORGANIGRAM. Defines the required separation between build/governance agents and runtime/onboard app agents, Maturion as the single user-facing AI interface, runtime specialist categories, APW specialist boundary, Maturion-as-CS2 authority maturity levels, runtime context envelope expectations, and ripple requirements.",
   "type": "canon",
   "path": "governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md",
   "layer_down_status": "PUBLIC_API",

--- a/.agent-admin/prehandover/proof-maturion-agent-network-organigram-canon-20260624.md
+++ b/.agent-admin/prehandover/proof-maturion-agent-network-organigram-canon-20260624.md
@@ -1,0 +1,101 @@
+# Pre-Handover Proof: Maturion Agent Network Organigram Canon
+
+**Proof ID**: proof-maturion-agent-network-organigram-canon-20260624  
+**Date**: 2026-06-24  
+**Repository**: `APGI-cmy/maturion-foreman-governance`  
+**Branch**: `canon-maturion-agent-network-organigram-v10`  
+**Governance Agent Role**: governance-repo-administrator  
+**Mode**: VUPR - Verify, Update, Propagate, Record
+
+---
+
+## 1. Scope
+
+Create governance canon from the merged `maturion-isms` strategy PR #1849:
+
+```text
+Maturion/strategy/Maturion_agent_network_organigram_strategy.md
+```
+
+Primary canon created:
+
+```text
+governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md
+```
+
+Ripple record created:
+
+```text
+governance/ripple/RIPPLE-MATURION-AGENT-NETWORK-ORGANIGRAM-20260624.md
+```
+
+---
+
+## 2. Verification Performed
+
+| Check | Result | Evidence |
+|---|---|---|
+| Governance administrator role loaded | PASS | `.agent-workspace/governance-repo-administrator/context/agent-role.md`; `governance/quality/agent-integrity/governance-repo-administrator-v2.agent.md` |
+| Source strategy read from consumer repo | PASS | `APGI-cmy/maturion-isms/Maturion/strategy/Maturion_agent_network_organigram_strategy.md` |
+| Existing orchestrator/specialist canon considered | PASS | `governance/canon/ORCHESTRATOR_SPECIALIST_ARCHITECTURE.md` |
+| Three-tier knowledge canon considered | PASS | `governance/canon/THREE_TIER_AGENT_KNOWLEDGE_ARCHITECTURE.md` |
+| Agent registry architecture considered | PASS | `governance/canon/AGENT_REGISTRY_ARCHITECTURE.md` |
+| Canon created as new file, not mutation of existing protected semantics | PASS | `MATURION_AGENT_NETWORK_ORGANIGRAM.md` added |
+| Ripple targets identified | PASS | ripple record added |
+| Runtime/build-time distinction preserved | PASS | canon Sections 3, 12, 16 |
+| Maturion-as-CS2 not activated | PASS | canon Sections 6 and 16 |
+| APW-specialist not activated | PASS | canon Sections 8 and 16 |
+| Public APW retrieval not enabled | PASS | canon Sections 8, 11 and 16 |
+
+---
+
+## 3. Known Blocker / Pending Alignment
+
+`governance/CANON_INVENTORY.json` must be updated with the new canon entry after the final canon text is fixed.
+
+Reason this proof records it explicitly:
+
+- The available GitHub connector supports full-file replacement but not patch operations.
+- `CANON_INVENTORY.json` is a large generated JSON file.
+- Performing a partial or reconstructed replacement through the connector would risk corrupting canonical inventory state.
+- The safe governance action is to record the required inventory alignment as a blocker/pending task rather than performing unsafe inventory mutation.
+
+Required inventory entry after final text is accepted:
+
+```json
+{
+  "filename": "MATURION_AGENT_NETWORK_ORGANIGRAM.md",
+  "version": "1.0.0 | **Authority**: CS2",
+  "file_hash": "702a6dc272c02b6741ada74e28ccfa05924c78b19465b6ac3dc9e42b13a83b92",
+  "effective_date": "2026-06-24",
+  "description": "Canonical governance document: MATURION_AGENT_NETWORK_ORGANIGRAM. Defines the required separation between build/governance agents and runtime/onboard app agents, Maturion as the single user-facing AI interface, runtime specialist categories, APW-specialist boundary, Maturion-as-CS2 authority maturity levels, runtime context envelope expectations, and ripple requirements.",
+  "type": "canon",
+  "path": "governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md",
+  "layer_down_status": "PUBLIC_API",
+  "file_hash_sha256": "702a6dc272c02b6741ada74e28ccfa05924c78b19465b6ac3dc9e42b13a83b92"
+}
+```
+
+If the canon text changes during review, the hash must be recomputed.
+
+---
+
+## 4. Ripple Disposition
+
+Immediate layer-down to consumers is intentionally deferred until governance PR merge because consumers should receive final merged canonical text and final hash.
+
+Required follow-up after governance merge:
+
+1. Add/align the canon entry in `governance/CANON_INVENTORY.json`.
+2. Update `GOVERNANCE_ARTIFACT_INVENTORY.md` if the repository inventory process requires manual artifact entries.
+3. Layer down canon to `APGI-cmy/maturion-isms`.
+4. Layer down awareness to `APGI-cmy/app_management_centre`.
+5. Layer down APW-specific awareness to `APGI-cmy/apgi-public-website`.
+
+---
+
+## 5. Handover Status
+
+**Status**: Draft governance PR suitable for CS2 / governance review, with inventory alignment explicitly recorded as a blocker before merge.
+
+This proof does not claim final merge readiness.

--- a/governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md
+++ b/governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md
@@ -1,0 +1,710 @@
+# MATURION_AGENT_NETWORK_ORGANIGRAM
+
+**Status**: CANONICAL | **Version**: 1.0.0 | **Authority**: CS2  
+**Effective Date**: 2026-06-24  
+**Source Strategy**: `APGI-cmy/maturion-isms/Maturion/strategy/Maturion_agent_network_organigram_strategy.md` v0.1.0, merged via PR #1849  
+**Layer-Down Status**: PUBLIC_API  
+**Canonical Home**: `APGI-cmy/maturion-foreman-governance/governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`
+
+---
+
+## 1. Purpose
+
+This canon establishes the mandatory structural model for the Maturion agent ecosystem.
+
+It defines:
+
+1. the separation between builder/governance agents and runtime/onboard application agents;
+2. Maturion's position as the single user-facing AI interface across APGI applications;
+3. the required categories of runtime specialists;
+4. the staged maturity model for any future Maturion-as-CS2 authority;
+5. registry and lifecycle requirements for runtime specialists;
+6. ripple obligations for consumer repositories that define or use Maturion, AIMC, app specialists, or build-governance agents.
+
+This canon exists to prevent agent sprawl, authority ambiguity, duplicate specialists, runtime/build-time conflation, unsafe knowledge access, and premature activation of agents that have not been governed.
+
+---
+
+## 2. Canonical Principle
+
+The Maturion ecosystem is governed by this principle:
+
+```text
+One Maturion interface. Many governed capabilities behind it.
+```
+
+Users interact with Maturion as a single coherent security professional. Internal routing, specialist consultation, app context assembly, knowledge retrieval, and memory access may occur behind the scenes, but the user must not be required to manage or understand the agent network unless transparency is necessary for trust, limitation disclosure, audit, approval, or safety.
+
+---
+
+## 3. Mandatory Separation: Build Agents and Runtime App Agents
+
+The ecosystem contains two distinct agent networks.
+
+### 3.1 Builder / Governance Agent Network
+
+Builder/governance agents operate around repositories, issues, PRs, pre-build artifacts, canon, gates, quality assurance, evidence, and delivery governance.
+
+They answer:
+
+```text
+How do we safely plan, build, review, govern, and merge platform work?
+```
+
+Examples include:
+
+- CS2 / Johan Ras;
+- Maturion-as-CS2 when and only when canonically authorised for that maturity level;
+- Foreman / Builder-Maturion;
+- builder agents;
+- IAA assurance roles;
+- ECAP/admin evidence roles;
+- QP/quality review roles;
+- CodexAdvisor / agent factory roles;
+- governance liaison agents;
+- repository or module build specialists.
+
+Builder/governance agents may use `.github/agents/` contracts, governance canon, pre-build artifacts, branch/PR evidence, CI status, delivery memory, and repository state.
+
+### 3.2 Runtime / Onboard App Agent Network
+
+Runtime/onboard app agents operate inside APGI products and applications. They support user-facing Maturion interactions, app-specific guidance, domain reasoning, knowledge retrieval, scoring, report writing, evidence interpretation, or specialist consultation.
+
+They answer:
+
+```text
+How does Maturion assist a user inside an app using governed subject knowledge, app context, tenant context, memory, and specialist capability?
+```
+
+Examples include:
+
+- Runtime Maturion;
+- APW specialist;
+- ISMS specialist;
+- MMM / Maturity Roadmap specialist;
+- MAT specialist;
+- PIT specialist;
+- XDETECT specialist;
+- risk-platform specialist;
+- document-parser specialist;
+- criteria-generator specialist;
+- maturity-scoring specialist;
+- report-writer specialist;
+- training/LMS specialist;
+- retrieval/ranking services;
+- memory/Arbiter-facing services.
+
+Runtime specialists may be inspired by `.github/agents/` contracts, but they must be governed through AIMC/runtime architecture and must not be assumed to be identical to build-time agents.
+
+### 3.3 Boundary Rule
+
+```text
+Build agents govern and build the system.
+Runtime agents operate inside the system for users.
+```
+
+No implementation may silently convert a build-time `.github/agents` contract into a production runtime specialist without:
+
+1. strategy alignment;
+2. canon coverage;
+3. runtime registry design;
+4. knowledge-plane rules;
+5. security and tenant-isolation review;
+6. test/evidence;
+7. CS2 approval.
+
+---
+
+## 4. Maturion's Canonical Position
+
+Maturion is the single AI interface and orchestration identity across APGI applications and embodiments.
+
+Maturion is responsible for:
+
+1. detecting app, embodiment, environment, user, organisation, tenant, industry, time, timezone, page/workflow, and permission context where available;
+2. selecting the correct knowledge planes;
+3. retrieving governed Subject Knowledge Domain material;
+4. retrieving app state and customer Framework / Context Domain material only when authenticated, authorised, and scoped;
+5. routing to specialists when specialist expertise is required;
+6. validating specialist outputs against guardrails, tenant boundaries, memory rules, and authority constraints;
+7. synthesising one coherent user-facing answer;
+8. escalating when knowledge, authority, safety, permissions, or specialist availability are insufficient.
+
+Runtime Maturion is not a mere chatbot and not a hollow router. Runtime Maturion owns context assembly, retrieval policy, source prioritisation, final synthesis, limitation disclosure, and safe communication.
+
+Specialists own deep-domain or app-specific reasoning within declared boundaries.
+
+---
+
+## 5. Canonical Agent Organigram
+
+### 5.1 Authority and Governance View
+
+```text
+CS2 / Johan Ras
+  |
+  |-- App Management Centre (future operating environment)
+  |     |
+  |     |-- Maturion-as-CS2 maturity path
+  |     |     |-- Level 0: Advisor
+  |     |     |-- Level 1: CS2 Proxy Evaluator
+  |     |     |-- Level 2: Delegated CS2 for low-risk governed actions
+  |     |     |-- Level 3: Operational CS2 Orchestrator
+  |     |     `-- Level 4: Autonomous CS2 with human override
+  |     |
+  |     |-- Builder / Governance Agent Network
+  |     |     |-- Foreman / Builder-Maturion
+  |     |     |-- Builder agents
+  |     |     |-- IAA assurance agents
+  |     |     |-- ECAP/admin evidence agents
+  |     |     |-- QP/quality reviewers
+  |     |     |-- CodexAdvisor / agent factory
+  |     |     `-- governance liaison agents
+  |     |
+  |     `-- Build project orchestration dashboards, gates, evidence and memory
+  |
+  `-- Product Runtime Ecosystem
+        |
+        `-- Runtime Maturion (single user-facing interface)
+              |
+              |-- App specialists
+              |     |-- APW specialist
+              |     |-- ISMS specialist
+              |     |-- MMM / Maturity Roadmap specialist
+              |     |-- MAT specialist
+              |     |-- PIT specialist
+              |     `-- XDETECT specialist
+              |
+              |-- Domain specialists
+              |     |-- risk-platform specialist
+              |     |-- security-controls specialist
+              |     |-- threat-intelligence specialist
+              |     `-- human-rights / VPSHR / training specialist
+              |
+              |-- Knowledge and data specialists
+              |     |-- document-parser specialist
+              |     |-- criteria-generator specialist
+              |     |-- knowledge-ingestion specialist
+              |     |-- retrieval/ranking specialist
+              |     `-- memory specialist / Arbiter-facing service
+              |
+              |-- Output specialists
+              |     |-- maturity-scoring specialist
+              |     |-- report-writer specialist
+              |     |-- evidence-pack specialist
+              |     `-- executive-summary specialist
+              |
+              `-- Oversight systems
+                    |-- Guardian
+                    |-- Sentinel
+                    `-- Arbiter
+```
+
+### 5.2 Runtime User Experience View
+
+```text
+User
+  |
+  `-- Maturion
+        |
+        |-- detects app/context/permissions
+        |-- retrieves governed knowledge
+        |-- consults specialists where needed
+        |-- validates output
+        `-- returns one coherent answer
+```
+
+The user experience must remain coherent. Internal routing may be logged for audit and debugging, but product design must not expose unmanaged agent fragmentation to ordinary users.
+
+---
+
+## 6. Maturion-as-CS2 Authority Maturity Model
+
+Maturion may not become operational CS2 merely because an app, strategy, prompt, branch, or runtime interface refers to that possibility.
+
+Any Maturion-as-CS2 authority must progress through staged maturity levels.
+
+### Level 0 - Advisor
+
+Maturion provides analysis, recommendations, risk flags, merge concerns, strategy drafts, suggested dispositions, and ready-to-paste review comments.
+
+Allowed:
+
+- recommend actions;
+- draft review comments;
+- identify gate risks;
+- compare evidence to canon;
+- propose next steps.
+
+Not allowed:
+
+- approve stages;
+- waive gates;
+- merge;
+- appoint builders autonomously;
+- issue final CS2 disposition.
+
+### Level 1 - CS2 Proxy Evaluator
+
+Maturion may evaluate a stage, PR, or disposition on Johan's behalf only when explicitly authorised for that repo, wave, scope, and time.
+
+Required:
+
+- explicit CS2 authorisation recorded for the wave;
+- transparent proxy wording;
+- evidence bundle present;
+- no material unresolved conflict;
+- limitations disclosed.
+
+### Level 2 - Delegated CS2 for Low-Risk Governed Actions
+
+Maturion may approve narrow, pre-defined, low-risk actions only where canon defines the action class, evidence requirement, rollback path, and escalation route.
+
+Examples may include:
+
+- documentation-only progression where all checks are satisfied;
+- tracker update acceptance after verified merge;
+- administrative signoff where no product behaviour changes.
+
+Not allowed without further canon:
+
+- security-sensitive runtime changes;
+- schemas or migrations;
+- tenant isolation changes;
+- secrets or configuration changes;
+- irreversible production decisions;
+- autonomy expansion.
+
+### Level 3 - Operational CS2 Orchestrator
+
+Maturion may orchestrate build projects through the App Management Centre, including wave setup, scope declaration, builder appointment proposals, gate tracking, CI/status inspection, evidence bundle validation, and CS2 disposition preparation.
+
+At this level, Maturion may issue delegated dispositions only for domains already covered by canon and only within measurable authority boundaries.
+
+### Level 4 - Autonomous CS2 with Human Override
+
+Maturion acts as operational CS2 across defined work classes, with Johan retaining override, audit review, and constitutional authority.
+
+This level requires:
+
+- mature canon;
+- stable memory architecture;
+- verified tenant isolation;
+- robust audit trails;
+- conflict escalation;
+- rollback and freeze mechanisms;
+- repeated proven reliability;
+- explicit CS2 approval.
+
+Level 4 must not be implemented from strategy, app ambition, or local code alone.
+
+---
+
+## 7. Runtime Specialist Categories
+
+### 7.1 App Specialists
+
+App specialists know product/application context, routes, workflows, public/private boundaries, user journeys, module authority, and handoff contracts.
+
+Canonical app-specialist categories include:
+
+| Specialist | Mandate |
+|---|---|
+| APW specialist | APGI public website, public-safe messaging, APW route intent, public Maturion widget context, public CTA and handoff behaviour |
+| ISMS specialist | ISMS shell, public front door, subscription, checkout, onboarding, shared user/org/tenant context, Ask Maturion continuity |
+| MMM / Maturity Roadmap specialist | Maturity roadmap flows, framework/domain/MPS/criteria state, roadmap sequencing and maturity workspace context |
+| MAT specialist | MAT workflows, LDCS, audit lifecycle, evidence, maturity assessment and criteria structure |
+| PIT specialist | Threat intelligence, IOC, TTP, CVE, STIX/TAXII, vulnerability prioritisation and PIT workflows |
+| XDETECT specialist | Detection workflows, contraband protocols, privacy-sensitive screening context |
+| App Management Centre specialist | Build-project orchestration, agent staffing, gate dashboards and Maturion-as-CS2 operating support |
+
+### 7.2 Domain Specialists
+
+Domain specialists know disciplines rather than apps.
+
+Examples include:
+
+- risk-platform specialist;
+- security-controls specialist;
+- threat-intelligence specialist;
+- human-rights / VPSHR specialist;
+- data analytics / remote assurance specialist;
+- training and capability-building specialist.
+
+### 7.3 Knowledge and Data Specialists
+
+Knowledge and data specialists support ingestion, parsing, retrieval, ranking, metadata inspection, and memory boundaries.
+
+Examples include:
+
+- document-parser specialist;
+- criteria-generator specialist;
+- knowledge-ingestion specialist;
+- retrieval/ranking specialist;
+- memory specialist or Arbiter-facing service.
+
+### 7.4 Output Specialists
+
+Output specialists transform governed reasoning into approved output formats.
+
+Examples include:
+
+- maturity-scoring specialist;
+- report-writer specialist;
+- evidence-pack specialist;
+- executive-summary specialist.
+
+---
+
+## 8. APW Specialist Canonical Requirement
+
+The APW specialist is a required missing runtime app specialist if public APW Maturion guidance is to become knowledge-grounded.
+
+### 8.1 Mandate
+
+The APW specialist is responsible for:
+
+- APGI public website route and content intent;
+- public-safe APGI messaging;
+- public loss-prevention and maturity narrative;
+- free maturity assessment handoff behaviour;
+- APGI Hub public explanation;
+- Maturion public widget behaviour and boundaries;
+- public route launch readiness and custom-domain status;
+- public privacy/terms/team placeholder state where applicable.
+
+### 8.2 Explicit Non-Scope
+
+The APW specialist must not access or answer from:
+
+- private ISMS workspaces;
+- customer tenant records;
+- Framework / Context Domain records;
+- Supabase service-role data;
+- confidential uploaded documents;
+- authenticated app state;
+- internal build governance not marked public-safe;
+- secret/configuration values.
+
+### 8.3 Public Retrieval Boundary
+
+Public APW mode may consult the APW specialist and public-safe knowledge only.
+
+Public APW retrieval must require an equivalent of:
+
+```text
+approval_status = 'approved'
+AND visibility = 'public'
+AND public_safe = true
+AND tenant_context = null
+```
+
+If the schema stores these values in JSON metadata rather than dedicated columns, the retrieval filter must enforce the metadata equivalent.
+
+If public-safe metadata does not exist, APW public retrieval must remain disabled or operate in explicitly disclosed non-grounded/degraded mode.
+
+---
+
+## 9. Knowledge Plane Rules
+
+Runtime Maturion and specialists must use explicit knowledge planes.
+
+### 9.1 Subject Knowledge Domain
+
+Subject Knowledge Domain teaches Maturion the discipline. It is CS2/superuser governed and includes approved security, loss-prevention, risk, maturity, standards, methodology, training, and Maturion doctrine.
+
+### 9.2 Framework / Context Domain
+
+Framework / Context Domain teaches Maturion about a specific customer's environment. It is organisation-scoped and must never bleed into other organisations or public APW mode.
+
+### 9.3 App Context Domain
+
+App Context Domain teaches Maturion where he is operating:
+
+- APW public website;
+- ISMS shell;
+- MMM workspace;
+- MAT audit workflow;
+- PIT threat intelligence workflow;
+- App Management Centre build orchestration;
+- future apps.
+
+### 9.4 Memory Domain
+
+Memory must be partitioned by authority and scope:
+
+- constitutional memory;
+- global subject memory;
+- app/embodiment memory;
+- tenant/org memory;
+- user/session memory;
+- episodic incident/watchdog memory.
+
+Private organisational data must never be written into global shared memory.
+
+---
+
+## 10. Runtime Context Envelope Requirement
+
+Every runtime Maturion request must eventually carry a context envelope sufficient to identify app, embodiment, user state, tenant scope, page/workflow, environment, and permission boundary.
+
+### 10.1 Public APW Example
+
+```json
+{
+  "app": "APW",
+  "embodiment": "public-web",
+  "environment": "production-or-preview",
+  "user": {
+    "authenticated": false,
+    "name": null,
+    "role": "public-visitor",
+    "organisation": null,
+    "industry": null,
+    "timezone": "Africa/Johannesburg"
+  },
+  "tenant": null,
+  "page": "/platform",
+  "module": "APGI-public-website",
+  "permission_scope": "public"
+}
+```
+
+### 10.2 Authenticated App Example
+
+```json
+{
+  "app": "MMM",
+  "embodiment": "authenticated-app",
+  "environment": "production",
+  "user": {
+    "authenticated": true,
+    "id": "<user-id>",
+    "name": "<user-name>",
+    "role": "<role>",
+    "organisation": "<organisation-id>",
+    "industry": "<industry>",
+    "timezone": "<timezone>"
+  },
+  "tenant": {
+    "organisation_id": "<organisation-id>",
+    "framework_id": "<framework-id-or-null>"
+  },
+  "page": "/maturity/frameworks/<id>",
+  "module": "Maturity Roadmap / MMM",
+  "permission_scope": "tenant-scoped"
+}
+```
+
+Specialists must receive only the context required for their task.
+
+---
+
+## 11. Retrieval Priority
+
+Maturion and specialists must use sources in this authority order:
+
+1. Tier 1 constitutional/canon/runtime rules.
+2. Approved Subject Knowledge Domain material.
+3. App-specific approved operational knowledge.
+4. Framework / Context Domain material only when authenticated and scoped.
+5. Current session input.
+6. Public internet/current-awareness material only when explicitly allowed and never as an override.
+
+Public APW mode must not retrieve tenant/customer context.
+
+If approved APGI knowledge is expected but not found, Maturion must disclose the limitation or answer cautiously within public-safe boundaries. Maturion must not invent APGI facts from general model memory when governed APGI knowledge is required.
+
+---
+
+## 12. Registry Requirements
+
+The ecosystem requires distinct registry concerns.
+
+### 12.1 Build/Governance Agent Registry
+
+Build/governance agent registration tracks build-time contracts, governance agents, Foreman, Builder, IAA, ECAP, CodexAdvisor and related delivery roles.
+
+Candidate existing locations include:
+
+- `.github/agents/`;
+- `governance/AGENT_REGISTRY.json`;
+- `.agent-workspace/<agent>/knowledge/`.
+
+### 12.2 Runtime Agent Registry
+
+Runtime/onboard application agents require a runtime registry before production activation.
+
+A runtime registry must include, at minimum:
+
+| Field | Purpose |
+|---|---|
+| `runtime_agent_id` | Stable runtime identifier |
+| `display_name` | Human/audit readable name |
+| `agent_class` | app-specialist, domain-specialist, knowledge-specialist, output-specialist, oversight-service |
+| `apps` | Apps where the specialist may be used |
+| `knowledge_planes` | Allowed knowledge planes |
+| `visibility_scope` | public, internal, tenant_scoped, superuser_only |
+| `status` | planned, stub, active, degraded, deprecated |
+| `orchestrator` | Usually Maturion |
+| `input_schema` | Runtime input contract |
+| `output_schema` | Runtime response/evidence contract |
+| `guardrails` | Applicable safety/tenant/memory controls |
+| `authority_limits` | What the specialist may not decide |
+| `audit_requirements` | Logging/evidence obligations |
+
+No runtime specialist may be treated as production-active until registry status, knowledge base, input/output schema, authority limits, and guardrails are defined.
+
+---
+
+## 13. Specialist Lifecycle
+
+Specialists must progress through explicit lifecycle states.
+
+```text
+PROPOSED
+  -> STRATEGY_DEFINED
+    -> STUB_CONTRACTED
+      -> KNOWLEDGE_BASED
+        -> RUNTIME_REGISTERED
+          -> ACTIVE
+            -> DEGRADED / DEPRECATED / RETIRED
+```
+
+### Lifecycle Rules
+
+1. `PROPOSED` means the specialist is named as a potential need only.
+2. `STRATEGY_DEFINED` means mandate, scope, non-scope and knowledge boundaries are documented.
+3. `STUB_CONTRACTED` means a build/governance or runtime stub exists but is not production-reliable.
+4. `KNOWLEDGE_BASED` means approved Tier 2/domain knowledge and retrieval boundaries exist.
+5. `RUNTIME_REGISTERED` means the specialist appears in the runtime registry with schemas, allowed apps, allowed knowledge planes, and status.
+6. `ACTIVE` means Maturion may invoke the specialist in production contexts within declared limits.
+7. `DEGRADED`, `DEPRECATED`, or `RETIRED` states must trigger graceful degradation and limitation disclosure where relevant.
+
+---
+
+## 14. Delegation Transparency Rules
+
+Maturion should normally hide internal routing from ordinary users unless transparency is useful, legally required, educational, or necessary to explain a limitation.
+
+### 14.1 Invisible Delegation
+
+Use invisible delegation when the specialist performs routine retrieval, formatting, scoring, classification or app-context interpretation.
+
+User experience:
+
+```text
+Maturion answers directly.
+```
+
+### 14.2 Transparent Delegation
+
+Use transparent delegation when:
+
+- the answer depends on a specialist limitation;
+- multiple expert perspectives disagree;
+- human approval is required;
+- a specialist is unavailable or stubbed;
+- the user explicitly asks how Maturion reached an answer;
+- audit or trust is improved by naming the source class or specialist.
+
+The user should still not have to manually route questions to specialists.
+
+---
+
+## 15. Runtime Refinement to Existing Orchestrator Principle
+
+Existing orchestrator canon correctly establishes:
+
+```text
+Orchestrators coordinate; specialists execute.
+```
+
+Runtime Maturion requires the following refinement:
+
+```text
+Runtime Maturion orchestrates, retrieves, frames, validates, and synthesises.
+Specialists execute deep-domain or app-specific reasoning within declared boundaries.
+```
+
+This refinement prevents two failures:
+
+1. Maturion becoming a hollow router with no contextual intelligence.
+2. Specialists becoming independent user-facing personas that fragment the product experience.
+
+Maturion remains the coherent interface and final synthesiser. Specialists remain bounded expert capability providers.
+
+---
+
+## 16. Activation Prohibitions
+
+This canon does not by itself:
+
+- activate APW specialist;
+- modify `.github/agents/`;
+- modify `governance/AGENT_REGISTRY.json`;
+- create a runtime agent registry;
+- implement public chat retrieval;
+- query or mutate Supabase;
+- grant CS2 authority to Maturion;
+- change memory write rules;
+- change tenant isolation rules;
+- change PR gates.
+
+Any such action requires its own governed wave, evidence, and CS2-approved progression.
+
+---
+
+## 17. Ripple Requirements
+
+Because this canon is `PUBLIC_API`, it must ripple to consumer repositories that define or use Maturion, AIMC, app specialists, build/governance agent contracts, or App Management Centre concepts.
+
+Minimum ripple targets include:
+
+- `APGI-cmy/maturion-isms`;
+- `APGI-cmy/app_management_centre`;
+- `APGI-cmy/apgi-public-website` where APW-specialist or public Maturion behaviour is affected;
+- any future AIMC/runtime specialist registry repository.
+
+Ripple must include:
+
+1. consumer awareness of the build/runtime agent split;
+2. consumer awareness that APW-specialist is recommended but not active until created and registered;
+3. consumer awareness that Maturion-as-CS2 authority remains staged and not granted by strategy or local code alone;
+4. consumer awareness that public APW retrieval requires public-safe approved metadata;
+5. consumer inventory/hash alignment once this canon is merged and hash-final.
+
+---
+
+## 18. Related Canon
+
+This canon must be interpreted with:
+
+- `ORCHESTRATOR_SPECIALIST_ARCHITECTURE.md`;
+- `AGENT_DELEGATION_PROTOCOL.md`;
+- `AGENT_REGISTRY_ARCHITECTURE.md`;
+- `THREE_TIER_AGENT_KNOWLEDGE_ARCHITECTURE.md`;
+- `AIMC_STRATEGY.md`;
+- `AIMC_SPECIALIST_OPERATING_MODEL.md`;
+- `LIVING_AGENT_SYSTEM.md`;
+- `AGENT_CREATION_BUNDLE_REQUIREMENTS.md`.
+
+Conflicts with tenant isolation, memory safety, or CS2 authority canon must escalate to CS2 rather than being locally interpreted.
+
+---
+
+## 19. Canonical Disposition
+
+The Maturion agent ecosystem is authorised to scale only through governed layers:
+
+```text
+Strategy
+  -> canon
+    -> registry architecture
+      -> specialist definition
+        -> knowledge grounding
+          -> runtime activation
+            -> CS2 authority maturation
+```
+
+Agent names alone do not create authority. Agent contracts alone do not create runtime activation. Runtime activation requires governed knowledge, registry state, guardrails, evidence and CS2 approval.

--- a/governance/ripple/RIPPLE-MATURION-AGENT-NETWORK-ORGANIGRAM-20260624.md
+++ b/governance/ripple/RIPPLE-MATURION-AGENT-NETWORK-ORGANIGRAM-20260624.md
@@ -1,0 +1,149 @@
+# Ripple Record: Maturion Agent Network Organigram Canon
+
+**Ripple ID**: RIPPLE-MATURION-AGENT-NETWORK-ORGANIGRAM-20260624  
+**Canon**: `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`  
+**Canon Version**: 1.0.0  
+**Authority**: CS2 - Johan Ras  
+**Date**: 2026-06-24  
+**Source Strategy**: `APGI-cmy/maturion-isms/Maturion/strategy/Maturion_agent_network_organigram_strategy.md` merged via maturion-isms PR #1849  
+**Governance Agent Role**: governance-repo-administrator / VUPR pattern
+
+---
+
+## 1. Ripple Trigger
+
+A new `PUBLIC_API` canon has been created to formalise the Maturion agent-network organigram.
+
+The canon establishes the mandatory distinction between:
+
+1. builder/governance agents; and
+2. runtime/onboard application agents.
+
+It also canonises Maturion's position as the single user-facing AI interface, the staged Maturion-as-CS2 authority model, specialist lifecycle states, public APW specialist boundaries, runtime context envelope expectations, and public-safe retrieval preconditions.
+
+---
+
+## 2. Touched Canonical Concepts
+
+| Concept | Ripple Impact |
+|---|---|
+| Build/governance agent contracts | Must not be treated as production runtime specialists without governed runtime registration. |
+| Runtime Maturion | Must remain the single coherent user-facing interface. |
+| App specialists | APW/ISMS/MMM/MAT/PIT/XDETECT specialists must be defined and activated through lifecycle states. |
+| Maturion-as-CS2 | Authority remains staged and must not be inferred from strategy, prompt, or local implementation alone. |
+| Public APW chat | Public retrieval must remain public-safe, approved, non-tenant, and metadata-filtered. |
+| Runtime registry | Must be designed before runtime specialists are considered active. |
+| Knowledge planes | Subject Knowledge, Framework/Context, App Context and Memory must stay separated. |
+
+---
+
+## 3. Ripple Targets
+
+### 3.1 Required Consumer Repositories
+
+| Repository | Reason | Required Action |
+|---|---|---|
+| `APGI-cmy/maturion-isms` | Contains source strategy, Maturion runtime strategy, AIMC, `.github/agents`, specialist registry and public chat gateway. | Layer down canon after governance merge; align strategy references; do not activate APW specialist until governed specialist wave. |
+| `APGI-cmy/app_management_centre` | Future home for Maturion-as-CS2 and build-project orchestration. | Add awareness that Maturion-as-CS2 authority is staged and not automatically granted. |
+| `APGI-cmy/apgi-public-website` | Public APW embodiment and Maturion chat widget. | Add awareness that APW-specialist is required before knowledge-grounded public APW guidance is treated as governed. |
+
+### 3.2 Conditional / Future Targets
+
+| Repository / Area | Condition |
+|---|---|
+| AIMC runtime registry | When runtime registry exists, register this canon as authority for runtime specialist lifecycle and activation states. |
+| Supabase/AIMC knowledge ingestion | When public retrieval is implemented, enforce `approved`, `public_safe`, `visibility=public`, non-tenant filters. |
+| App Management Centre authority flows | When Maturion-as-CS2 is implemented, bind actions to the authority maturity model. |
+
+---
+
+## 4. Conflict Scan
+
+### 4.1 Existing Orchestrator/Specialist Canon
+
+`ORCHESTRATOR_SPECIALIST_ARCHITECTURE.md` establishes that orchestrators coordinate and specialists execute. The new canon does not replace that rule. It refines it for runtime Maturion:
+
+```text
+Runtime Maturion orchestrates, retrieves, frames, validates, and synthesises.
+Specialists execute deep-domain or app-specific reasoning within declared boundaries.
+```
+
+No direct conflict identified. The new canon is a specialisation layer for runtime Maturion and agent-network structure.
+
+### 4.2 Agent Registry Canon
+
+`AGENT_REGISTRY_ARCHITECTURE.md` governs build/governance agent registration. The new canon requires a future runtime registry but does not modify the existing build/governance registry.
+
+No direct conflict identified. Future work must avoid overloading the existing build registry unless a separate canon authorises that design.
+
+### 4.3 Three-Tier Knowledge Architecture
+
+`THREE_TIER_AGENT_KNOWLEDGE_ARCHITECTURE.md` governs Tier 1, Tier 2 and Tier 3 knowledge. The new canon extends this into runtime knowledge-plane separation: Subject Knowledge, Framework/Context, App Context and Memory.
+
+No direct conflict identified. Future runtime retrieval implementation must map these planes back to Tier 1/Tier 2/Tier 3 controls.
+
+### 4.4 AIMC Strategy / Specialist Operating Model
+
+AIMC canon remains the owning platform model for AI capability and specialist operation. The new canon provides network structure and activation prohibitions, not provider or implementation design.
+
+No conflict identified. Future AIMC runtime registry work should cite this canon.
+
+### 4.5 APW Public Chat
+
+The new canon explicitly blocks tenant/private retrieval in public APW mode and requires public-safe metadata before knowledge-grounded public retrieval.
+
+No conflict identified. This adds a safety boundary before APW public chat v0.3 retrieval work.
+
+---
+
+## 5. Immediate Ripple Disposition
+
+| Item | Status | Note |
+|---|---|---|
+| Governance canon created | Complete in branch | `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md` |
+| Ripple record created | Complete in branch | This file |
+| Consumer repo layer-down | Pending after governance PR merge | Requires final hash / merged canonical state |
+| CANON_INVENTORY hash alignment | Pending / requires inventory update | New canon SHA256 pre-merge content hash recorded below |
+| Runtime specialist activation | Not authorised | Separate governed waves required |
+| APW-specialist creation | Not authorised by this PR | Separate governed wave recommended |
+| Maturion-as-CS2 activation | Not authorised by this PR | Requires authority maturity canon and App Management Centre implementation wave |
+
+---
+
+## 6. Pre-Merge Canon Hash Evidence
+
+The new canon content SHA256, computed before inventory alignment, is:
+
+```text
+702a6dc272c02b6741ada74e28ccfa05924c78b19465b6ac3dc9e42b13a83b92
+```
+
+This hash must be rechecked after any review edits. Consumer repo inventories should not be updated until the governance PR is merged and the final canon content is fixed.
+
+---
+
+## 7. Required Follow-Up Waves
+
+1. **Governance inventory alignment**  
+   Add `MATURION_AGENT_NETWORK_ORGANIGRAM.md` to `governance/CANON_INVENTORY.json` and `GOVERNANCE_ARTIFACT_INVENTORY.md` with final hash.
+
+2. **Layer-down to `maturion-isms`**  
+   Ripple the canon into the consumer repo and align strategy references.
+
+3. **Layer-down to `app_management_centre`**  
+   Add awareness that Maturion-as-CS2 authority is staged and canon-gated.
+
+4. **Layer-down to `apgi-public-website`**  
+   Add awareness that APW-specialist is required for governed public APW guidance and that public retrieval must be public-safe.
+
+5. **Runtime registry strategy/canon**  
+   Define runtime specialist registry before activating app specialists.
+
+6. **APW specialist definition wave**  
+   Create APW-specialist only after registry and lifecycle rules are accepted.
+
+---
+
+## 8. Governance Administrator Note
+
+This ripple record intentionally separates immediate canon creation from downstream consumer updates. The consumer layer-down should occur after governance PR merge so all consumers receive the final canonical hash and not a draft branch hash.


### PR DESCRIPTION
## Summary

Creates canonical governance for the Maturion agent-network organigram, derived from the merged `maturion-isms` strategy PR #1849.

Adds:

- `governance/canon/MATURION_AGENT_NETWORK_ORGANIGRAM.md`
- `governance/ripple/RIPPLE-MATURION-AGENT-NETWORK-ORGANIGRAM-20260624.md`
- `.agent-admin/prehandover/proof-maturion-agent-network-organigram-canon-20260624.md`

## What the canon establishes

- Mandatory separation between builder/governance agents and runtime/onboard app agents.
- Maturion as the single user-facing AI interface.
- Runtime specialist categories: app, domain, knowledge/data, output, and oversight.
- APW-specialist as a required missing runtime app specialist before APW public guidance can be treated as governed/knowledge-grounded.
- Public APW retrieval boundary: approved + public-safe + non-tenant + visibility filtered.
- Maturion-as-CS2 authority maturity model from Advisor through Autonomous CS2 with human override.
- Runtime context-envelope expectations.
- Specialist lifecycle states and runtime registry requirements.
- Ripple obligations for `maturion-isms`, `app_management_centre`, and APW.

## Boundary

This PR does **not**:

- activate APW-specialist;
- modify `.github/agents/`;
- modify `governance/AGENT_REGISTRY.json`;
- create a runtime agent registry;
- implement public chat retrieval;
- query or mutate Supabase;
- grant CS2 authority to Maturion;
- change memory write rules;
- change tenant isolation rules;
- change PR gates.

## Governance / ripple note

This is a draft PR because inventory alignment must still be handled safely before merge.

`governance/CANON_INVENTORY.json` is a large generated JSON file. The available connector supports full-file replacement but not safe patch operations. I therefore recorded the exact pending inventory entry and hash in the pre-handover proof rather than risking inventory corruption.

Pre-merge canon SHA256 recorded in proof:

```text
702a6dc272c02b6741ada74e28ccfa05924c78b19465b6ac3dc9e42b13a83b92
```

If review edits change the canon text, the hash must be recomputed before inventory alignment and consumer ripple.

## Ripple targets

- `APGI-cmy/maturion-isms`
- `APGI-cmy/app_management_centre`
- `APGI-cmy/apgi-public-website` where APW public Maturion behaviour is affected

Consumer layer-down should occur after this governance canon is merged and hash-final.